### PR TITLE
han 1030 사진 및 기록 관리 기능 추가 및 테스트

### DIFF
--- a/src/main/java/com/choongang/frombirth_backend/controller/ChildrenController.java
+++ b/src/main/java/com/choongang/frombirth_backend/controller/ChildrenController.java
@@ -39,13 +39,13 @@ public class ChildrenController {
     }
 
 
-    @PutMapping // 아이 프로필 업데이트
+    @PutMapping("/update") // 아이 프로필 업데이트
     public ResponseEntity<Void> updateChild(@RequestBody ChildrenDTO childrenDTO) {
         childrenService.updateChild(childrenDTO);
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/{childId}") // 아이 프로필 삭제
+    @DeleteMapping("/delete/{childId}") // 아이 프로필 삭제
     public ResponseEntity<Void> deleteChild(@PathVariable Integer childId) {
         childrenService.deleteChild(childId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/choongang/frombirth_backend/controller/PhotoController.java
+++ b/src/main/java/com/choongang/frombirth_backend/controller/PhotoController.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/photos")
+@CrossOrigin(origins = "*") // 모든 출처 허용 (개발용)
 public class PhotoController {
     private final PhotoService photoService;
 
@@ -18,29 +19,29 @@ public class PhotoController {
         this.photoService = photoService;
     }
 
-    @GetMapping("/record/{recordId}")
+    @GetMapping("/all/{recordId}")
     public ResponseEntity<List<PhotoDTO>> getAllPhotos(@PathVariable Integer recordId) {
         return ResponseEntity.ok(photoService.getAllPhotos(recordId));
     }
 
-    @GetMapping("/{photoId}")
+    @GetMapping("/record/{photoId}")
     public ResponseEntity<PhotoDTO> getPhotoById(@PathVariable Integer photoId) {
         return ResponseEntity.ok(photoService.getPhotoById(photoId));
     }
 
-    @PostMapping
+    @PostMapping("/create")
     public ResponseEntity<Void> addPhoto(@RequestBody PhotoDTO photoDTO) {
         photoService.addPhoto(photoDTO);
         return ResponseEntity.status(201).build();
     }
 
-    @PutMapping
+    @PutMapping("/update")
     public ResponseEntity<Void> updatePhoto(@RequestBody PhotoDTO photoDTO) {
         photoService.updatePhoto(photoDTO);
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/{photoId}")
+    @DeleteMapping("/delete/{photoId}")
     public ResponseEntity<Void> deletePhoto(@PathVariable Integer photoId) {
         photoService.deletePhoto(photoId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/choongang/frombirth_backend/controller/RecordController.java
+++ b/src/main/java/com/choongang/frombirth_backend/controller/RecordController.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/records")
+@CrossOrigin(origins = "*") // 모든 출처 허용 (개발용)
 public class RecordController {
     private final RecordService recordService;
 
@@ -18,29 +19,29 @@ public class RecordController {
         this.recordService = recordService;
     }
 
-    @GetMapping("/child/{childId}")
+    @GetMapping("/all/{childId}") // 아이의 전체 기록 불러오기
     public ResponseEntity<List<RecordDTO>> getAllRecords(@PathVariable Integer childId) {
         return ResponseEntity.ok(recordService.getAllRecords(childId));
     }
 
-    @GetMapping("/{recordId}")
+    @GetMapping("/child/{recordId}") // 아이의 기록 불러오기
     public ResponseEntity<RecordDTO> getRecordById(@PathVariable Integer recordId) {
         return ResponseEntity.ok(recordService.getRecordById(recordId));
     }
 
-    @PostMapping
+    @PostMapping("/create") //아이 기록 생성
     public ResponseEntity<Void> addRecord(@RequestBody RecordDTO recordDTO) {
         recordService.addRecord(recordDTO);
         return ResponseEntity.status(201).build();
     }
 
-    @PutMapping
+    @PutMapping("/update")
     public ResponseEntity<Void> updateRecord(@RequestBody RecordDTO recordDTO) {
         recordService.updateRecord(recordDTO);
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/{recordId}")
+    @DeleteMapping("/delete/{recordId}")
     public ResponseEntity<Void> deleteRecord(@PathVariable Integer recordId) {
         recordService.deleteRecord(recordId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/choongang/frombirth_backend/controller/WeeklyReportController.java
+++ b/src/main/java/com/choongang/frombirth_backend/controller/WeeklyReportController.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/reports")
+@CrossOrigin(origins = "*") // 모든 출처 허용 (개발용)
 public class WeeklyReportController {
     private final WeeklyReportService weeklyReportService;
 

--- a/src/main/java/com/choongang/frombirth_backend/service/impl/ChildrenServiceImpl.java
+++ b/src/main/java/com/choongang/frombirth_backend/service/impl/ChildrenServiceImpl.java
@@ -40,6 +40,9 @@ public class ChildrenServiceImpl implements ChildrenService {
     @Override
     public void addChild(ChildrenDTO childrenDTO) { // 프로필생성 
         Children child = modelMapper.map(childrenDTO, Children.class);
+
+        // 프로필 생성 시간 설정
+        child.setCreatedAt(LocalDateTime.now());
         childrenRepository.save(child);
     }
 

--- a/src/main/java/com/choongang/frombirth_backend/service/impl/PhotoServiceImpl.java
+++ b/src/main/java/com/choongang/frombirth_backend/service/impl/PhotoServiceImpl.java
@@ -8,6 +8,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,12 +39,14 @@ public class PhotoServiceImpl implements PhotoService {
     @Override
     public void addPhoto(PhotoDTO photoDTO) {
         Photo photo = modelMapper.map(photoDTO, Photo.class);
+        photo.setCreatedAt(LocalDateTime.now());
         photoRepository.save(photo);
     }
 
     @Override
     public void updatePhoto(PhotoDTO photoDTO) {
         Photo photo = modelMapper.map(photoDTO, Photo.class);
+        photo.setCreatedAt(LocalDateTime.now());
         photoRepository.save(photo);
     }
 

--- a/src/main/java/com/choongang/frombirth_backend/service/impl/RecordServiceImpl.java
+++ b/src/main/java/com/choongang/frombirth_backend/service/impl/RecordServiceImpl.java
@@ -8,6 +8,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,14 +39,38 @@ public class RecordServiceImpl implements RecordService {
     @Override
     public void addRecord(RecordDTO recordDTO) {
         Record record = modelMapper.map(recordDTO, Record.class);
+        record.setCreatedAt(LocalDateTime.now()); // 레코드 생성 시간 설정
         recordRepository.save(record);
     }
 
     @Override
     public void updateRecord(RecordDTO recordDTO) {
-        Record record = modelMapper.map(recordDTO, Record.class);
-        recordRepository.save(record);
+        Record existingRecord = recordRepository.findById(recordDTO.getRecordId())
+                .orElseThrow(() -> new IllegalArgumentException("Record not found"));
+
+        // height가 null이 아닐 때만 업데이트
+        if (recordDTO.getHeight() != null) {
+            existingRecord.setHeight(recordDTO.getHeight());
+        }
+        // weight가 null이 아닐 때만 업데이트
+        if (recordDTO.getWeight() != null) {
+            existingRecord.setWeight(recordDTO.getWeight());
+        }
+        // content가 null이 아닐 때만 업데이트
+        if (recordDTO.getContent() != null) {
+            existingRecord.setContent(recordDTO.getContent());
+        }
+        // videoResult가 null이 아닐 때만 업데이트
+        if (recordDTO.getVideoResult() != null) {
+            existingRecord.setVideoResult(recordDTO.getVideoResult());
+        }
+
+        // 마지막 수정 시간 설정
+        existingRecord.setUpdatedAt(LocalDateTime.now());
+
+        recordRepository.save(existingRecord);
     }
+
 
     @Override
     public void deleteRecord(Integer recordId) {


### PR DESCRIPTION
- Record 및 Photo 엔티티와 관련 컨트롤러, 서비스, DTO 생성 및 설정
- RecordController: 기록 추가, 조회, 수정, 삭제 기능 구현
  - /api/records 엔드포인트 추가
  - 자녀 ID로 기록 전체 조회 및 개별 기록 조회 기능 추가
- PhotoController: 사진 추가, 조회, 수정, 삭제 기능 구현
  - /api/photos 엔드포인트 추가
  - recordId 기반 전체 사진 조회 및 개별 사진 조회 기능 추가
- RecordServiceImpl: 기록 업데이트 시 null 값 조건 처리 로직 추가
- Boomerang 테스트용 JSON 데이터 예시 포함 (api 명세서 참조)
